### PR TITLE
Added Question Bank Functionality

### DIFF
--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -241,6 +241,7 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 
 	$scope.openQuestionBankDialog = ->
 		$scope.questionBankDialog = true
+		$scope.enableQuestionBank = false
 
 	$scope.closeQuestionBankDialog = ->
 		$scope.questionBankDialog = false

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -97,9 +97,10 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 	$scope.partial = false
 	$scope.random = false
 	$scope.attempts = 5
-	$scope.questionBankDialog = false
+	$scope.questionBankModal = false
 	$scope.enableQuestionBank = false
 	$scope.questionBankVal = 1
+	$scope.questionBankValTemp = 1
 
 	# for use with paginating results
 	$scope.currentPage = 0;
@@ -194,7 +195,12 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 		$scope.hideCover()
 
 	$scope.hideCover = ->
-		$scope.showTitleDialog = $scope.showIntroDialog = $scope.questionBankDialog = false
+		$scope.showTitleDialog = $scope.showIntroDialog = $scope.questionBankModal = false
+		$scope.questionBankValTemp = $scope.questionBankVal
+
+	$scope.validateQuestionBankVal = ->
+		if ($scope.questionBankValTemp >= 1 && $scope.questionBankValTemp <= $scope.items.length)
+			$scope.questionBankVal = $scope.questionBankValTemp
 
 	$scope.initNewWidget = (widget, baseUrl) ->
 		$scope.$apply ->
@@ -207,6 +213,8 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 		$scope.random = qset.options.random
 		$scope.enableQuestionBank = if qset.options.enableQuestionBank then qset.options.enableQuestionBank else false
 		$scope.questionBankVal = if qset.options.questionBankVal then qset.options.questionBankVal else 1
+		$scope.questionBankValTemp = if qset.options.questionBankVal then qset.options.questionBankVal else 1
+
 		$scope.onQuestionImportComplete qset.items[0].items
 
 		$scope.$apply()

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -205,8 +205,8 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 		$scope.attempts = ~~qset.options.attempts or 5
 		$scope.partial = qset.options.partial
 		$scope.random = qset.options.random
-		$scope.enableQuestionBank = qset.options.enableQuestionBank
-		$scope.questionBankVal = qset.options.questionBankVal
+		$scope.enableQuestionBank = false
+		$scope.questionBankVal = if qset.options.questionBankVal then qset.options.questionBankVal else false
 		$scope.onQuestionImportComplete qset.items[0].items
 
 		$scope.$apply()

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -239,13 +239,6 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 		,
 		400
 
-	$scope.openQuestionBankDialog = ->
-		$scope.questionBankDialog = true
-		$scope.enableQuestionBank = false
-
-	$scope.closeQuestionBankDialog = ->
-		$scope.questionBankDialog = false
-
 	$scope.addItem = (ques = "", ans = "", id = "") ->
 		pages = $scope.numberOfPages()
 		$scope.items.push {ques:ques, ans:ans, foc:false, id: id }

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -194,7 +194,7 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 		$scope.hideCover()
 
 	$scope.hideCover = ->
-		$scope.showTitleDialog = $scope.showIntroDialog = false
+		$scope.showTitleDialog = $scope.showIntroDialog = $scope.questionBankDialog = false
 
 	$scope.initNewWidget = (widget, baseUrl) ->
 		$scope.$apply ->

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -28,7 +28,7 @@ Hangman.directive('focusMe', ['$timeout', '$parse', ($timeout, $parse) ->
 ])
 
 Hangman.factory 'Resource', ['$sanitize', ($sanitize) ->
-	buildQset: (title, items, partial, attempts, random) ->
+	buildQset: (title, items, partial, attempts, random, enableQuestionBank, questionBankVal) ->
 		qsetItems = []
 		qset = {}
 
@@ -47,7 +47,7 @@ Hangman.factory 'Resource', ['$sanitize', ($sanitize) ->
 					Materia.CreatorCore.cancelSave 'Word #'+(i+1)+' needs to contain at least one letter or number.'
 					return false
 
-		qset.options = {partial: partial, attempts: attempts, random: random}
+		qset.options = {partial: partial, attempts: attempts, random: random, enableQuestionBank: enableQuestionBank, questionBankVal: questionBankVal}
 		qset.assets = []
 		qset.rand = false
 		qset.name = title
@@ -97,6 +97,9 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 	$scope.partial = false
 	$scope.random = false
 	$scope.attempts = 5
+	$scope.questionBankDialog = false
+	$scope.enableQuestionBank = false
+	$scope.questionBankVal = 0
 
 	# for use with paginating results
 	$scope.currentPage = 0;
@@ -202,12 +205,14 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 		$scope.attempts = ~~qset.options.attempts or 5
 		$scope.partial = qset.options.partial
 		$scope.random = qset.options.random
+		$scope.enableQuestionBank = qset.options.enableQuestionBank
+		$scope.questionBankVal = qset.options.questionBankVal
 		$scope.onQuestionImportComplete qset.items[0].items
 
 		$scope.$apply()
 
 	$scope.onSaveClicked = (mode = 'save') ->
-		qset = Resource.buildQset $sanitize($scope.title), $scope.items, $scope.partial, $scope.attempts, $scope.random
+		qset = Resource.buildQset $sanitize($scope.title), $scope.items, $scope.partial, $scope.attempts, $scope.random, $scope.enableQuestionBank, $scope.questionBankVal
 		if qset then Materia.CreatorCore.save $sanitize($scope.title), qset
 
 	$scope.onSaveComplete = (title, widget, qset, version) -> true
@@ -233,6 +238,12 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 			window.scrollTo({ left: 0, top: height, behavior: 'smooth'})
 		,
 		400
+
+	$scope.openQuestionBankDialog = ->
+		$scope.questionBankDialog = true
+
+	$scope.closeQuestionBankDialog = ->
+		$scope.questionBankDialog = false
 
 	$scope.addItem = (ques = "", ans = "", id = "") ->
 		pages = $scope.numberOfPages()

--- a/src/creator.coffee
+++ b/src/creator.coffee
@@ -99,7 +99,7 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 	$scope.attempts = 5
 	$scope.questionBankDialog = false
 	$scope.enableQuestionBank = false
-	$scope.questionBankVal = 0
+	$scope.questionBankVal = 1
 
 	# for use with paginating results
 	$scope.currentPage = 0;
@@ -205,8 +205,8 @@ Hangman.controller 'HangmanCreatorCtrl', ['$timeout', '$scope', '$sanitize', 'Re
 		$scope.attempts = ~~qset.options.attempts or 5
 		$scope.partial = qset.options.partial
 		$scope.random = qset.options.random
-		$scope.enableQuestionBank = false
-		$scope.questionBankVal = if qset.options.questionBankVal then qset.options.questionBankVal else false
+		$scope.enableQuestionBank = if qset.options.enableQuestionBank then qset.options.enableQuestionBank else false
+		$scope.questionBankVal = if qset.options.questionBankVal then qset.options.questionBankVal else 1
 		$scope.onQuestionImportComplete qset.items[0].items
 
 		$scope.$apply()

--- a/src/creator.html
+++ b/src/creator.html
@@ -27,7 +27,12 @@
 			<div class="logo"></div>
 			<h1 id="title" ng-bind="title" ng-click="showTitleDialog = true"></h1>
 			<div ng-click="showTitleDialog = true" class="link">Edit...</div>
-			<button class= "questionBankButton" ng-click="questionBankDialog = !questionBankDialog">Question Bank</button>
+			<button
+				ng-class= "{'questionBankButton': true, 'gray-out': !enableQuestionBank}"
+				ng-click="questionBankDialog = !questionBankDialog"
+				ng-disabled="items.length === 0">
+				Question Bank: {{enableQuestionBank === true ? "ON" : "OFF"}}
+			</button>
 			<span class="attempts">
 				<p>Incorrect guesses per phrase</p>
 				<div class="slide-btn">
@@ -170,34 +175,10 @@
 			<span>{{currentPage+1}}/{{numberOfPages()}}</span>
 			<button ng-disabled="currentPage >= numberOfPages() - 1" ng-click="currentPage=currentPage+1">Next</button>
 		</div>
-		<div ng-show= "questionBankDialog" class="overlay"></div>
-		<div class="questionBankDialog-wrapper" ng-show= "questionBankDialog">
-				<div class="questionBankDialog">
-					<div class="enable-qb-question">
-						<strong>Enable question bank? </strong>
-						<div>
-							<span>
-								<input type="radio" ng-model="enableQuestionBank" ng-value=false> No</input>
-								<input type="radio" ng-model="enableQuestionBank" ng-value=true> Yes</input>
-							</span>
-						</div>
-					</div>
-					<div>
-						<span ng-show="enableQuestionBank" >
-							<strong>How many questions to ask? </strong>
-							<div>
-								<input class="numInput" type="number" ng-model="questionBankVal" ng-attr-min="{{items.length < 1 ? items.length : 1}}" ng-attr-max="{{items.length}}" step="1">
-								<span> out of {{items.length}} </span>
-							</div>
-						</span>
-					</div>
-				</div>
-				<button class="dialogCloseButton" ng-click="(questionBankVal <= items.length && questionBankVal > 0) && (questionBankDialog = !questionBankDialog)">Okay</button>
-		</div>
 		<div ng-show="!items.length &amp;&amp; step" class="arrow-box">
 			<span>Click here to add your first question</span>
 		</div>
-		<div id="backgroundcover" ng-click="hideCover()" ng-class="{ show: showTitleDialog || showIntroDialog }"></div>
+		<div id="backgroundcover" ng-click="hideCover()" ng-class="{ show: showTitleDialog || showIntroDialog || questionBankDialog }"></div>
 		<div ng-class="{ show: showIntroDialog }" class="box intro">
 			<img src="assets/creator_example.png">
 			<h1>Guess the Phrase</h1>
@@ -213,5 +194,29 @@
 			<input type="text" placeholder="My Guess the Phrase widget" ng-model="title" focus-me="showTitleDialog" ng-enter="hideCover()">
 			<input type="button" value="Done" ng-click="hideCover()">
 		</div>
+		<div ng-class="{ show: questionBankDialog }" ng-click= 'hideCover()' class="box questionBankDialog">
+			<div class="enable-qb-question">
+				<strong>Enable question bank? </strong>
+				<div class="enable-qb-options" ng-click="$event.stopPropagation()">
+					<span>
+						<input type="radio" ng-model="enableQuestionBank" ng-value=false> No</input>
+						<input type="radio" ng-model="enableQuestionBank" ng-value=true> Yes</input>
+					</span>
+				</div>
+			</div>
+			<div>
+				<span ng-show="enableQuestionBank" >
+					<strong>How many questions to ask? </strong>
+					<div class="num-input-wrapper" ng-click="$event.stopPropagation()">
+						<input class="numInput" type="number" ng-model="questionBankVal" ng-attr-min="{{items.length < 1 ? items.length : 1}}" ng-attr-max="{{items.length}}" step="1">
+						<span> out of {{items.length}} </span>
+					</div>
+				</span>
+			</div>
+			<button class="dialogCloseButton"
+			ng-click="(questionBankVal <= items.length && questionBankVal > 0) && (questionBankDialog = !questionBankDialog)"
+			ng-disabled="questionBankVal < 0 || questionBankVal > items.length">Confirm</button>
+		</div>
+
 	</body>
 </html>

--- a/src/creator.html
+++ b/src/creator.html
@@ -184,11 +184,11 @@
 						<strong>How many questions to ask?</strong>
 						<br/>
 						<input class="numInput" type="number" ng-model="questionBankVal" ng-attr-min="{{items.length < 1 ? items.length : 1}}" ng-attr-max="{{items.length}}" step="1">
-						<span> out of {{items.length}}</span>
+						<span> out of {{items.length}} </span>
 					</span>
 					<br/>
 				</div>
-				<button class="dialogCloseButton" ng-click="questionBankDialog = !questionBankDialog">Okay</button>
+				<button class="dialogCloseButton" ng-click="(questionBankVal <= items.length && questionBankVal > 0) && (questionBankDialog = !questionBankDialog)">Okay</button>
 		</div>
 		<div ng-show="!items.length &amp;&amp; step" class="arrow-box">
 			<span>Click here to add your first question</span>

--- a/src/creator.html
+++ b/src/creator.html
@@ -171,22 +171,26 @@
 			<button ng-disabled="currentPage >= numberOfPages() - 1" ng-click="currentPage=currentPage+1">Next</button>
 		</div>
 		<div ng-show= "questionBankDialog" class="overlay"></div>
-		<div class="questionBank-wrapper" ng-show= "questionBankDialog">
-				<div class="questionBank-content">
-					<strong>Enable question bank? </strong>
-					<br/>
-					<span>
-						<input type="radio" ng-model="enableQuestionBank" ng-value=false> No</input>
-						<input type="radio" ng-model="enableQuestionBank" ng-value=true> Yes</input>
-					</span>
-					<br/><br/>
-					<span ng-show="enableQuestionBank" >
-						<strong>How many questions to ask?</strong>
-						<br/>
-						<input class="numInput" type="number" ng-model="questionBankVal" ng-attr-min="{{items.length < 1 ? items.length : 1}}" ng-attr-max="{{items.length}}" step="1">
-						<span> out of {{items.length}} </span>
-					</span>
-					<br/>
+		<div class="questionBankDialog-wrapper" ng-show= "questionBankDialog">
+				<div class="questionBankDialog">
+					<div class="enable-qb-question">
+						<strong>Enable question bank? </strong>
+						<div>
+							<span>
+								<input type="radio" ng-model="enableQuestionBank" ng-value=false> No</input>
+								<input type="radio" ng-model="enableQuestionBank" ng-value=true> Yes</input>
+							</span>
+						</div>
+					</div>
+					<div>
+						<span ng-show="enableQuestionBank" >
+							<strong>How many questions to ask? </strong>
+							<div>
+								<input class="numInput" type="number" ng-model="questionBankVal" ng-attr-min="{{items.length < 1 ? items.length : 1}}" ng-attr-max="{{items.length}}" step="1">
+								<span> out of {{items.length}} </span>
+							</div>
+						</span>
+					</div>
 				</div>
 				<button class="dialogCloseButton" ng-click="(questionBankVal <= items.length && questionBankVal > 0) && (questionBankDialog = !questionBankDialog)">Okay</button>
 		</div>

--- a/src/creator.html
+++ b/src/creator.html
@@ -28,8 +28,8 @@
 			<h1 id="title" ng-bind="title" ng-click="showTitleDialog = true"></h1>
 			<div ng-click="showTitleDialog = true" class="link">Edit...</div>
 			<button
-				ng-class= "{'questionBankButton': true, 'gray-out': !enableQuestionBank}"
-				ng-click="questionBankDialog = !questionBankDialog"
+				ng-class= "{'qb-button': true, 'gray-out': !enableQuestionBank}"
+				ng-click="questionBankModal = !questionBankModal"
 				ng-disabled="items.length === 0">
 				Question Bank: {{enableQuestionBank === true ? "ON" : "OFF"}}
 			</button>
@@ -178,7 +178,7 @@
 		<div ng-show="!items.length &amp;&amp; step" class="arrow-box">
 			<span>Click here to add your first question</span>
 		</div>
-		<div id="backgroundcover" ng-click="hideCover()" ng-class="{ show: showTitleDialog || showIntroDialog || questionBankDialog }"></div>
+		<div id="backgroundcover" ng-click="hideCover()" ng-class="{ show: showTitleDialog || showIntroDialog || questionBankModal }"></div>
 		<div ng-class="{ show: showIntroDialog }" class="box intro">
 			<img src="assets/creator_example.png">
 			<h1>Guess the Phrase</h1>
@@ -194,28 +194,28 @@
 			<input type="text" placeholder="My Guess the Phrase widget" ng-model="title" focus-me="showTitleDialog" ng-enter="hideCover()">
 			<input type="button" value="Done" ng-click="hideCover()">
 		</div>
-		<div ng-class="{ show: questionBankDialog }" ng-click= 'hideCover()' class="box questionBankDialog">
+		<div ng-class="{ show: questionBankModal }" ng-click= 'hideCover()' class="box question-bank-dialog">
 			<div class="enable-qb-question">
-				<strong>Enable question bank? </strong>
+				<label style="font-weight: bold;">Enable question bank? </label>
 				<div class="enable-qb-options" ng-click="$event.stopPropagation()">
 					<span>
 						<input type="radio" ng-model="enableQuestionBank" ng-value=false> No</input>
-						<input type="radio" ng-model="enableQuestionBank" ng-value=true> Yes</input>
+						<input type="radio" ng-model="enableQuestionBank" ng-change="questionBankValTemp = questionBankVal = items.length" ng-value=true> Yes</input>
 					</span>
 				</div>
 			</div>
 			<div>
 				<span ng-show="enableQuestionBank" >
-					<strong>How many questions to ask? </strong>
+					<label style="font-weight: bold;">How many questions to ask? </label>
 					<div class="num-input-wrapper" ng-click="$event.stopPropagation()">
-						<input class="numInput" type="number" ng-model="questionBankVal" ng-attr-min="{{items.length < 1 ? items.length : 1}}" ng-attr-max="{{items.length}}" step="1">
+						<input class="num-input" type="number" ng-model="questionBankValTemp" ng-change="validateQuestionBankVal()" step="1">
 						<span> out of {{items.length}} </span>
 					</div>
 				</span>
 			</div>
-			<button class="dialogCloseButton"
-			ng-click="(questionBankVal <= items.length && questionBankVal > 0) && (questionBankDialog = !questionBankDialog)"
-			ng-disabled="questionBankVal < 0 || questionBankVal > items.length">Confirm</button>
+			<button class="dialog-close-button"
+			ng-click="questionBankModal = false"
+			ng-disabled="questionBankValTemp < 1 || questionBankValTemp > items.length">Confirm</button>
 		</div>
 
 	</body>

--- a/src/creator.html
+++ b/src/creator.html
@@ -27,6 +27,7 @@
 			<div class="logo"></div>
 			<h1 id="title" ng-bind="title" ng-click="showTitleDialog = true"></h1>
 			<div ng-click="showTitleDialog = true" class="link">Edit...</div>
+			<button class= "questionBankButton" ng-click="openQuestionBankDialog()">Question Bank</button>
 			<span class="attempts">
 				<p>Incorrect guesses per phrase</p>
 				<div class="slide-btn">
@@ -169,23 +170,25 @@
 			<span>{{currentPage+1}}/{{numberOfPages()}}</span>
 			<button ng-disabled="currentPage >= numberOfPages() - 1" ng-click="currentPage=currentPage+1">Next</button>
 		</div>
-		<button ng-show= "!questionBankDialog" ng-click="openQuestionBankDialog()">Enable Question Bank</button>
-		<div ng-show= "questionBankDialog">
-			<div>
-				<div>
-					<strong>Enable Question Bank? </strong>
+		<div ng-show= "questionBankDialog" class="overlay"></div>
+		<div class="questionBank-wrapper" ng-show= "questionBankDialog">
+				<div class="questionBank-content">
+					<strong>Enable question bank? </strong>
+					<br/>
 					<span>
-						<input type="radio" ng-model="enableQuestionBank" value="false"> No {{enableQuestionBank}} </input>
-						<input type="radio" ng-model="enableQuestionBank" value="true"> Yes {{enableQuestionBank}}</input>
+						<input type="radio" ng-model="enableQuestionBank" ng-value=false> No</input>
+						<input type="radio" ng-model="enableQuestionBank" ng-value=true> Yes</input>
 					</span>
-					<span>
-						<strong>How many questions do you want to ask?</strong>
-						<input type="number" ng-model="questionBankVal" min="1" max=qset.items step="1">
-						<span> Out of {{items.length}} annnd {{questionBankVal}}</span>
+					<br/><br/>
+					<span ng-show="enableQuestionBank" >
+						<strong>How many questions to ask?</strong>
+						<br/>
+						<input class="numInput" type="number" ng-model="questionBankVal" ng-attr-min="{{items.length < 1 ? items.length : 1}}" ng-attr-max="{{items.length}}" step="1">
+						<span> out of {{items.length}}</span>
 					</span>
+					<br/>
 				</div>
-				<button ng-click="closeQuestionBankDialog()">Close</button>
-			</div>
+				<button class="dialogCloseButton" ng-click="closeQuestionBankDialog()">Okay</button>
 		</div>
 		<div ng-show="!items.length &amp;&amp; step" class="arrow-box">
 			<span>Click here to add your first question</span>

--- a/src/creator.html
+++ b/src/creator.html
@@ -27,7 +27,7 @@
 			<div class="logo"></div>
 			<h1 id="title" ng-bind="title" ng-click="showTitleDialog = true"></h1>
 			<div ng-click="showTitleDialog = true" class="link">Edit...</div>
-			<button class= "questionBankButton" ng-click="openQuestionBankDialog()">Question Bank</button>
+			<button class= "questionBankButton" ng-click="questionBankDialog = !questionBankDialog">Question Bank</button>
 			<span class="attempts">
 				<p>Incorrect guesses per phrase</p>
 				<div class="slide-btn">
@@ -188,7 +188,7 @@
 					</span>
 					<br/>
 				</div>
-				<button class="dialogCloseButton" ng-click="closeQuestionBankDialog()">Okay</button>
+				<button class="dialogCloseButton" ng-click="questionBankDialog = !questionBankDialog">Okay</button>
 		</div>
 		<div ng-show="!items.length &amp;&amp; step" class="arrow-box">
 			<span>Click here to add your first question</span>

--- a/src/creator.html
+++ b/src/creator.html
@@ -169,7 +169,24 @@
 			<span>{{currentPage+1}}/{{numberOfPages()}}</span>
 			<button ng-disabled="currentPage >= numberOfPages() - 1" ng-click="currentPage=currentPage+1">Next</button>
 		</div>
-
+		<button ng-show= "!questionBankDialog" ng-click="openQuestionBankDialog()">Enable Question Bank</button>
+		<div ng-show= "questionBankDialog">
+			<div>
+				<div>
+					<strong>Enable Question Bank? </strong>
+					<span>
+						<input type="radio" ng-model="enableQuestionBank" value="false"> No {{enableQuestionBank}} </input>
+						<input type="radio" ng-model="enableQuestionBank" value="true"> Yes {{enableQuestionBank}}</input>
+					</span>
+					<span>
+						<strong>How many questions do you want to ask?</strong>
+						<input type="number" ng-model="questionBankVal" min="1" max=qset.items step="1">
+						<span> Out of {{items.length}} annnd {{questionBankVal}}</span>
+					</span>
+				</div>
+				<button ng-click="closeQuestionBankDialog()">Close</button>
+			</div>
+		</div>
 		<div ng-show="!items.length &amp;&amp; step" class="arrow-box">
 			<span>Click here to add your first question</span>
 		</div>

--- a/src/creator.html
+++ b/src/creator.html
@@ -58,8 +58,16 @@
 			</span>
 			<div class="random partial">
 				<p>Randomize Order</p>
-				<input type="checkbox" id="randomize" ng-model="random">
-				<label for="randomize" class="checktoggle"></label>
+				<input type="checkbox" ng-checked=enableQuestionBank ng-disabled=enableQuestionBank id="randomize" ng-model="random">
+				<label for="randomize" ng-class="{'disabled-look': enableQuestionBank}" class="checktoggle"></label>
+			</div>
+			<div class="question-tip randomizer-tip">?
+				<div class="qtip-box">
+					<p>
+						If <b>Question Bank</b> is on then the check to randomize order is disabled. This is because the question bank
+						randomizes the question order already.
+					</p>
+				</div>
 			</div>
 			<div class="partial">
 				<p>Partial scoring</p>
@@ -213,6 +221,7 @@
 					</div>
 				</span>
 			</div>
+			<p class="qb-warning">If question bank is enabled, questions will be randomized. </p>
 			<button class="dialog-close-button"
 			ng-click="questionBankModal = false"
 			ng-disabled="questionBankValTemp < 1 || questionBankValTemp > items.length">Confirm</button>

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -490,7 +490,7 @@ button.add-question {
 	left: 50%;
 	margin: 0;
 	transform: translate(-50%, -50%);
-	background-color: white;
+	background-color: #ffffff;
 	padding: 0;
 	height: 200px;
 	width: 300px;
@@ -503,7 +503,7 @@ button.add-question {
 		margin-top: 0;
 		padding: 0;
 		width: unset;
-		background: white;
+		background: #ffffff;
 		font-size: 17px;
 		text-align: center;
 		border: none;
@@ -552,7 +552,7 @@ button.add-question {
 
 		&:disabled {
 			background-color: #cccccc;
-			color: white;
+			color: #ffffff;
 		}
 	}
 }

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -780,7 +780,7 @@ button.add-question {
 	}
 }
 
-.questionBank-wrapper {
+.questionBankDialog-wrapper {
 	position: fixed;
   	top: 50%;
   	left: 50%;
@@ -790,17 +790,25 @@ button.add-question {
 	background-color: white;
 	color: black;
 	height: 300px;
-	width: 300px;
+	width: 250px;
 	z-index: 10000;
 	display: flex;
 	justify-content: center;
 	align-items: center;
 
-	.questionBank-content {
-		.numInput {
-			width: 35px;
-		}
+	.questionBankDialog {
 		margin: 15px;
+
+		.numInput {
+			width: 30px;
+			margin-top: 10px;
+		}
+
+		.enable-qb-question {
+			margin-top: 15px;
+			margin-bottom: 15px;
+		}
+
 	}
 
 	.dialogCloseButton {

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -619,6 +619,14 @@ button.add-question {
 		top: 28px;
 		background: #fff;
 	}
+
+	.questionBankButton {
+		position: absolute;
+		background-color: #5a5a5a;
+		right: 550px;
+		top: 35px;
+	}
+
 	.attempts {
 		position: absolute;
 		right: 355px;
@@ -771,6 +779,49 @@ button.add-question {
 		}
 	}
 }
+
+.questionBank-wrapper {
+	position: fixed;
+  	top: 50%;
+  	left: 50%;
+  	transform: translate(-50%, -50%);
+	border: 5px solid greenyellow;
+	border-radius: 5px;
+	background-color: white;
+	color: black;
+	height: 300px;
+	width: 300px;
+	z-index: 10000;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	.questionBank-content {
+		.numInput {
+			width: 35px;
+		}
+		margin: 15px;
+	}
+
+	.dialogCloseButton {
+		position: absolute;
+		bottom: 10px;
+		background-color: rgb(26, 244, 171);
+		color: black;
+	}
+
+}
+
+// To blur the background while the dialog is open
+.overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	z-index: 9000;
+	backdrop-filter: blur(5px);
+  }
 
 .question-tip {
 	position: absolute;

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -483,6 +483,81 @@ button.add-question {
 	}
 }
 
+.questionBankDialog {
+
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	margin: 0;
+	transform: translate(-50%, -50%);
+	background-color: white;
+	padding: 0;
+	height: 200px;
+	width: 300px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction: column;
+
+	input {
+		margin-top: 0;
+		padding: 0;
+		width: unset;
+		background: white;
+		font-size: 17px;
+		text-align: center;
+		border: none;
+		vertical-align: unset;
+		font-family: 'Lato';
+	}
+	.num-input-wrapper {
+		display: flex;
+		justify-content: center;
+		width: 100%;
+		align-items: center;
+		margin-bottom: 15px;
+
+		.numInput {
+			color: black;
+			outline: 1px solid black;
+			width: 35px;
+			margin: 2px 5px 0 0;
+		}
+	}
+
+	.enable-qb-question {
+		margin-top: 15px;
+		margin-bottom: 15px;
+
+		.enable-qb-options {
+			display: flex;
+			justify-content: center;
+		}
+	}
+
+	.dialogCloseButton {
+		position: relative;
+		margin-top: 5px;
+		margin-bottom: 5px;
+		font-size: 15px;
+		width: 100px;
+		background-color: #70bd34;
+		color: black;
+
+		&:hover {
+			background-color: #88df45;
+			border: 1px solid #88df45;
+			color: black;
+			cursor: pointer;
+		}
+
+		&:disabled {
+			background-color: #cccccc;
+			color: white;
+		}
+	}
+}
+
 .arrow-box {
 	position: absolute;
 	background: #fbf767;
@@ -622,9 +697,37 @@ button.add-question {
 
 	.questionBankButton {
 		position: absolute;
-		background-color: #5a5a5a;
+		background-color: $green;
+		color: #fff;
+		width: unset;
 		right: 550px;
 		top: 35px;
+
+		&:hover {
+			background-color: #7AD038;
+			cursor: pointer;
+		}
+
+		&:disabled {
+			background-color: #ccc;
+			border: 1px solid #ccc;
+			color: #fff;
+			cursor: not-allowed;
+		}
+
+		&.gray-out:not(:disabled) {
+			background-color: #5a5a5a;
+			border: 1px solid #5a5a5a;
+			color: #fff;
+
+			&:hover {
+				background-color: #938f8f;
+				border: 1px solid #938f8f;
+				cursor: pointer;
+			}
+
+		}
+
 	}
 
 	.attempts {
@@ -779,57 +882,6 @@ button.add-question {
 		}
 	}
 }
-
-.questionBankDialog-wrapper {
-	position: fixed;
-  	top: 50%;
-  	left: 50%;
-  	transform: translate(-50%, -50%);
-	border: 5px solid greenyellow;
-	border-radius: 5px;
-	background-color: white;
-	color: black;
-	height: 300px;
-	width: 250px;
-	z-index: 10000;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-
-	.questionBankDialog {
-		margin: 15px;
-
-		.numInput {
-			width: 30px;
-			margin-top: 10px;
-		}
-
-		.enable-qb-question {
-			margin-top: 15px;
-			margin-bottom: 15px;
-		}
-
-	}
-
-	.dialogCloseButton {
-		position: absolute;
-		bottom: 10px;
-		background-color: rgb(26, 244, 171);
-		color: black;
-	}
-
-}
-
-// To blur the background while the dialog is open
-.overlay {
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	z-index: 9000;
-	backdrop-filter: blur(5px);
-  }
 
 .question-tip {
 	position: absolute;

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -515,7 +515,7 @@ button.add-question {
 		justify-content: center;
 		width: 100%;
 		align-items: center;
-		margin-bottom: 15px;
+		margin-bottom: 5px;
 
 		.num-input {
 			color: black;
@@ -533,6 +533,11 @@ button.add-question {
 			display: flex;
 			justify-content: center;
 		}
+	}
+	.qb-warning {
+		font-size: 14px;
+		margin: 0;
+		text-align: center;
 	}
 
 	.dialog-close-button {
@@ -699,7 +704,7 @@ button.add-question {
 		background-color: $green;
 		color: #fff;
 		width: unset;
-		right: 550px;
+		right: 590px;
 		top: 35px;
 
 		&:hover {
@@ -731,7 +736,7 @@ button.add-question {
 
 	.attempts {
 		position: absolute;
-		right: 355px;
+		right: 395px;
 		cursor: pointer;
 		top:0px;
 
@@ -874,10 +879,17 @@ button.add-question {
 	.random {
 		position: absolute;
 		top: 0px;
-		right: 185px;
+		right: 225px;
 		font-family: "Lato";
+
 		label.checktoggle {
 			left: 24px;
+
+			&.disabled-look {
+				background-color: #676363;
+				opacity: 0.5;
+				cursor: not-allowed;
+			}
 		}
 	}
 }
@@ -898,6 +910,9 @@ button.add-question {
 
 	transition: all 0.15s ease;
 
+	&.randomizer-tip {
+		right: 190px;
+	}
 	&:hover {
 		opacity: 1;
 		background: #53a1d1;
@@ -959,6 +974,10 @@ button.add-question {
 		b {
 			font-weight: 400;
 		}
+	}
+
+	&.randomize-tooltip {
+		right: 180px;
 	}
 
 }

--- a/src/creator.scss
+++ b/src/creator.scss
@@ -483,7 +483,7 @@ button.add-question {
 	}
 }
 
-.questionBankDialog {
+.question-bank-dialog {
 
 	position: fixed;
 	top: 50%;
@@ -517,7 +517,7 @@ button.add-question {
 		align-items: center;
 		margin-bottom: 15px;
 
-		.numInput {
+		.num-input {
 			color: black;
 			outline: 1px solid black;
 			width: 35px;
@@ -527,7 +527,7 @@ button.add-question {
 
 	.enable-qb-question {
 		margin-top: 15px;
-		margin-bottom: 15px;
+		margin-bottom: 10px;
 
 		.enable-qb-options {
 			display: flex;
@@ -535,10 +535,9 @@ button.add-question {
 		}
 	}
 
-	.dialogCloseButton {
+	.dialog-close-button {
 		position: relative;
-		margin-top: 5px;
-		margin-bottom: 5px;
+		margin: 15 0 10 0;
 		font-size: 15px;
 		width: 100px;
 		background-color: #70bd34;
@@ -695,7 +694,7 @@ button.add-question {
 		background: #fff;
 	}
 
-	.questionBankButton {
+	.qb-button {
 		position: absolute;
 		background-color: $green;
 		color: #fff;

--- a/src/player.coffee
+++ b/src/player.coffee
@@ -285,6 +285,9 @@ HangmanEngine.controller 'HangmanEngineCtrl', ['$scope', '$timeout', 'Parse', 'R
 				Hangman.Draw.playAnimation 'torso', 'pander'
 				$scope.anvilStage = 1
 
+	$scope.prepareQuestionBank = (qsetArr, questionBankVal) ->
+		return _shuffle(qsetArr.items).slice(0, questionBankVal)
+
 	$scope.startQuestion = ->
 
 		$scope.$apply ->
@@ -323,10 +326,10 @@ HangmanEngine.controller 'HangmanEngineCtrl', ['$scope', '$timeout', 'Parse', 'R
 				$scope.max = Reset.attempts ~~_qset.options.attempts
 				$scope.keyboard = Reset.keyboard()
 			), 500
-				
+
 
 	_shuffle = (a) ->
-		for i in [1...a.length]
+		for i in [0...a.length]
 			j = Math.floor Math.random() * (a.length)
 			[a[i], a[j]] = [a[j], a[i]]
 		a
@@ -343,6 +346,11 @@ HangmanEngine.controller 'HangmanEngineCtrl', ['$scope', '$timeout', 'Parse', 'R
 
 		if _qset.options.random
 			_qset.items[0].items = _shuffle _qset.items[0].items
+
+		if(_qset.options.random and _qset.options.enableQuestionBank)
+			_qset.items[0].items = _qset.items[0].items.slice(0, _qset.options.questionBankVal)
+		else if(qset.options.enableQuestionBank)
+			_qset.items[0].items = window.scope.prepareQuestionBank(qset.items[0], qset.options.questionBankVal)
 
 		$scope.total = _qset.items[0].items.length
 		$scope.max = Reset.attempts ~~_qset.options.attempts


### PR DESCRIPTION
Users can now make widgets and select a few of the questions to be used as the question bank. The way the question bank is implemented, the set of total questions will be shuffled and then the widget will select as many to display as the user stated. I also added some guards so the set of questions wouldn't get shuffled twice (which could've happened if the user selects to randomize the qset). Please let me know if you find any errors or have any comments about the functionality/appearance of the changes; I know the CSS could likely use a boost. 